### PR TITLE
addState()

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,1 @@
+semi: false

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,1 +1,3 @@
 semi: false
+singleQuote: true
+trailingComma: all

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/node": "^12.0.0",
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.9.0",
+    "ad-hok": "^0.0.30",
     "lodash": "^4.17.15",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,34 +1,20 @@
-import React from "react";
-import logo from "./logo.svg";
-import "./App.css";
-import { addState } from "ad-hok";
-import { get } from "lodash/fp";
+import React from "react"
+import { addState } from "ad-hok"
+import { flow } from "lodash/fp"
 
-const fOfP = <A, B>(a: A) => (b: B) => b;
+interface AppProps {
+  externalProp: string
+}
 
-const t = fOfP(1)(3);
-
-const testFunc = addState("name", "setName", "hello")({ someProps: 3 });
-
-const App: React.FC = () => {
-  return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.tsx</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+const App: React.FC<AppProps> = flow(
+  addState("name", "setName", "hello"),
+  ({ name, setName, externalProp }) => (
+    <div>
+      <span>External prop: {externalProp}</span>
+      <span>Name: {name}</span>
+      <button onClick={() => setName("abc")}>set name</button>
     </div>
-  );
-};
+  )
+)
 
-export default App;
+export default App

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,48 @@
-import React from "react"
-import { addState } from "ad-hok"
-import { flow } from "lodash/fp"
+import React, { FC } from 'react'
+import { addState } from 'ad-hok'
+import { flow } from 'lodash/fp'
+
+interface AddStateInitialStateAsCallbackProps {
+  name: string
+}
+
+const AddStateInitialStateAsCallback: FC<AddStateInitialStateAsCallbackProps> = flow(
+  addState('value', 'setValue', ({ name }) => 'name: ' + name),
+  // addState<number>('num', 'setNum'),
+  addState('num', 'setNum', undefined as number | undefined),
+  ({ name, value, num, setNum }) => (
+    <div>
+      <div>name: {name}</div>
+      <div>value: {value}</div>
+      <div>num: {num}</div>
+      <button
+        onClick={() =>
+          setNum(
+            // 'a' // correctly disallowed
+            3,
+          )
+        }
+      >
+        set num
+      </button>
+    </div>
+  ),
+)
 
 interface AppProps {
   externalProp: string
 }
 
-const App: React.FC<AppProps> = flow(
-  addState("name", "setName", "hello"),
+const App: FC<AppProps> = flow(
+  addState('name', 'setName', 'hello'),
   ({ name, setName, externalProp }) => (
     <div>
-      <span>External prop: {externalProp}</span>
-      <span>Name: {name}</span>
-      <button onClick={() => setName("abc")}>set name</button>
+      <div>External prop: {externalProp}</div>
+      <div>Name: {name}</div>
+      <button onClick={() => setName('abc')}>set name</button>
+      <AddStateInitialStateAsCallback name={name} />
     </div>
-  )
+  ),
 )
 
 export default App

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import './index.css';
-import App from './App';
-import * as serviceWorker from './serviceWorker';
+import React from "react"
+import ReactDOM from "react-dom"
+import "./index.css"
+import App from "./App"
+import * as serviceWorker from "./serviceWorker"
 
-ReactDOM.render(<App />, document.getElementById('root'));
+ReactDOM.render(<App externalProp="def" />, document.getElementById("root"))
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.
 // Learn more about service workers: https://bit.ly/CRA-PWA
-serviceWorker.unregister();
+serviceWorker.unregister()

--- a/types/ad-hok/index.d.ts
+++ b/types/ad-hok/index.d.ts
@@ -1,14 +1,15 @@
-declare module "ad-hok" {
+declare module 'ad-hok' {
   type AddStateType = <
     TState,
     TStateName extends string,
-    TStateUpdaterName extends string
+    TStateUpdaterName extends string,
+    TProps
   >(
     stateName: TStateName,
     stateUpdaterName: TStateUpdaterName,
-    initialState: TState
-  ) => <TProps>(
-    props: TProps
+    initialState: TState | ((props: TProps) => TState),
+  ) => (
+    props: TProps,
   ) => TProps &
     { [stateName in TStateName]: TState } &
     { [stateUpdaterName in TStateUpdaterName]: (state: TState) => void }

--- a/types/ad-hok/index.d.ts
+++ b/types/ad-hok/index.d.ts
@@ -1,24 +1,19 @@
 declare module "ad-hok" {
-  interface FunctionOfProps<TProps, Additions> {
-    (props: TProps): TProps & Additions;
-  }
-
   type AddStateType = <
     TState,
     TStateName extends string,
-    TStateUpdaterName extends string,
-    TProps
+    TStateUpdaterName extends string
   >(
     stateName: TStateName,
     stateUpdaterName: TStateUpdaterName,
     initialState: TState
-  ) => FunctionOfProps<
-    TProps,
+  ) => <TProps>(
+    props: TProps
+  ) => TProps &
     { [stateName in TStateName]: TState } &
-      { [stateUpdaterName in TStateUpdaterName]: (state: TState) => void }
-  >;
+    { [stateUpdaterName in TStateUpdaterName]: (state: TState) => void }
 
-  declare const addState: AddStateType;
+  declare const addState: AddStateType
 }
 
 // declare module "ad-hok" {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1772,6 +1772,11 @@ acorn@^7.1.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
   integrity sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
 
+ad-hok@^0.0.30:
+  version "0.0.30"
+  resolved "https://registry.yarnpkg.com/ad-hok/-/ad-hok-0.0.30.tgz#5404e7f84235a12dcbf054c0a98e3a184bb7c541"
+  integrity sha512-wq3C6e9C0wGWOVMOl9/qqjXtTVghyAfsVQ86DyRQ+ke+eV+iXQIjIvIlyIlkMGjdtw/76KpKhP61N7y5FyZ9rQ==
+
 address@1.1.2, address@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/address/-/address-1.1.2.tgz#bf1116c9c758c51b7a933d296b72c221ed9428b6"


### PR DESCRIPTION
In this PR:
- updated `addState()` typing
- updated `<App>` to take an external prop and be a `flow()` consisting of an `addState()` and a render step

Building fine and in VS Code it's eg yelling at me if I destructure another nonexistent prop in the render function or misuse one of the existing props